### PR TITLE
Add Russian localization and responsive play tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="AI-powered fitness training with pose detection. Battle bosses by doing squats and push-ups!" />
+    <meta name="description" content="Фитнес‑тренировки с ИИ и распознаванием поз. Сражайтесь с боссами, выполняя приседания и отжимания!" />
     <meta name="theme-color" content="#ef4444" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Fitness Boss Fight - AI-Powered Workouts</title>
+    <title>Fitness Boss Fight - Тренировки с ИИ</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,26 +1,12 @@
 {
-  "name": "Fitness Boss Fight",
-  "short_name": "FitnessBoss",
-  "description": "AI-powered fitness training with pose detection",
+  "name": "Битва Фитнес Босса",
+  "short_name": "ФитнесБосс",
+  "description": "Фитнес-тренировки с ИИ и распознаванием поз",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0f0f0f",
   "theme_color": "#ef4444",
   "orientation": "portrait-primary",
-  "icons": [
-    {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icon-512.png", 
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any maskable"
-    }
-  ],
   "categories": ["fitness", "health", "sports"],
   "screenshots": [
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
     }
 
     // Update document title
-    document.title = 'Fitness Boss Fight - AI-Powered Workouts';
+    document.title = 'Fitness Boss Fight - Тренировки с ИИ';
     
     // Add meta tags for better PWA experience
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');

--- a/src/components/GamePlay.tsx
+++ b/src/components/GamePlay.tsx
@@ -8,6 +8,18 @@ import type { Boss, Exercise, ExerciseState, GameSession } from '../types';
 import bossesData from '../data/bosses.json';
 import exercisesData from '../data/exercises.json';
 
+const difficultyLabels: Record<string, string> = {
+  easy: 'легкий',
+  medium: 'средний',
+  hard: 'сложный'
+};
+
+const phaseLabels: Record<ExerciseState['phase'], string> = {
+  neutral: 'нейтрально',
+  down: 'вниз',
+  up: 'вверх'
+};
+
 const GamePlay: React.FC = () => {
   const navigate = useNavigate();
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -38,29 +50,65 @@ const GamePlay: React.FC = () => {
 
   const initializeCamera = useCallback(async () => {
     try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            width: 640,
-            height: 480,
-            facingMode: 'user'
-          }
-        });
-
-        if (videoRef.current) {
-          videoRef.current.srcObject = stream;
-          streamRef.current = stream;
-          setHasCamera(true);
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          width: 640,
+          height: 480,
+          facingMode: 'user'
         }
+      });
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        streamRef.current = stream;
+        setHasCamera(true);
+      }
     } catch (error) {
       console.error('Camera access denied:', error);
       setHasCamera(false);
     }
   }, []);
 
+  const endGame = useCallback((result: 'victory' | 'defeat') => {
+    if (gameTimer.current) {
+      clearInterval(gameTimer.current);
+    }
+    if (animationId.current) {
+      cancelAnimationFrame(animationId.current);
+    }
+
+    setIsPlaying(false);
+    setGamePhase('finished');
+    setGameResult(result);
+
+    // Play audio feedback
+    if (result === 'victory') {
+      audioManager.current.playVictory();
+      audioManager.current.vibrate([100, 100, 100]);
+    } else {
+      audioManager.current.playDefeat();
+      audioManager.current.vibrate(500);
+    }
+
+    // Save session
+    const session: GameSession = {
+      id: Date.now().toString(),
+      bossId: selectedBoss.id,
+      exerciseId: selectedExercise.id,
+      reps: exerciseState.reps,
+      accuracy: exerciseState.reps > 0 ? Math.min(exerciseState.combo / exerciseState.reps * 100, 100) : 0,
+      duration: 120 - timeLeft,
+      victory: result === 'victory',
+      timestamp: Date.now()
+    };
+
+    storageManager.current.saveSession(session);
+  }, [selectedBoss, selectedExercise, exerciseState, timeLeft]);
+
   const startGame = useCallback(async () => {
     await exerciseDetector.current.initialize();
     await audioManager.current.initialize();
-    
+
     setBossHP(selectedBoss.maxHP);
     exerciseDetector.current.reset();
     setTimeLeft(120);
@@ -99,42 +147,6 @@ const GamePlay: React.FC = () => {
     }
   }, [isPlaying, endGame]);
 
-  const endGame = useCallback((result: 'victory' | 'defeat') => {
-    if (gameTimer.current) {
-      clearInterval(gameTimer.current);
-    }
-    if (animationId.current) {
-      cancelAnimationFrame(animationId.current);
-    }
-
-    setIsPlaying(false);
-    setGamePhase('finished');
-    setGameResult(result);
-
-    // Play audio feedback
-    if (result === 'victory') {
-      audioManager.current.playVictory();
-      audioManager.current.vibrate([100, 100, 100]);
-    } else {
-      audioManager.current.playDefeat();
-      audioManager.current.vibrate(500);
-    }
-
-    // Save session
-    const session: GameSession = {
-      id: Date.now().toString(),
-      bossId: selectedBoss.id,
-      exerciseId: selectedExercise.id,
-      reps: exerciseState.reps,
-      accuracy: exerciseState.reps > 0 ? Math.min(exerciseState.combo / exerciseState.reps * 100, 100) : 0,
-      duration: 120 - timeLeft,
-      victory: result === 'victory',
-      timestamp: Date.now()
-    };
-
-    storageManager.current.saveSession(session);
-  }, [selectedBoss, selectedExercise, exerciseState, timeLeft]);
-
   const drawPoseOverlay = useCallback(() => {
     const canvas = canvasRef.current;
     const video = videoRef.current;
@@ -151,7 +163,7 @@ const GamePlay: React.FC = () => {
     // Draw exercise guidance
     ctx.fillStyle = exerciseState.phase === 'down' ? '#ef4444' : exerciseState.phase === 'up' ? '#22c55e' : '#6b7280';
     ctx.font = '24px Arial';
-    ctx.fillText(`${selectedExercise.name}: ${exerciseState.phase}`, 20, 40);
+    ctx.fillText(`${selectedExercise.name}: ${phaseLabels[exerciseState.phase]}`, 20, 40);
   }, [exerciseState.phase, selectedExercise.name]);
 
   const processFrame = useCallback(async () => {
@@ -243,7 +255,7 @@ const GamePlay: React.FC = () => {
       <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin text-4xl mb-4">⚡</div>
-          <p>Loading AI models...</p>
+          <p>Загрузка моделей ИИ...</p>
         </div>
       </div>
     );
@@ -272,7 +284,7 @@ const GamePlay: React.FC = () => {
       {gamePhase === 'setup' && (
         <div className="p-4 space-y-6">
           <div>
-            <h3 className="text-lg font-semibold mb-3">Choose Boss</h3>
+            <h3 className="text-lg font-semibold mb-3">Выберите босса</h3>
             <div className="grid grid-cols-1 gap-3">
               {bossesData.map((boss) => (
                 <button
@@ -298,7 +310,7 @@ const GamePlay: React.FC = () => {
                         boss.difficulty === 'easy' ? 'text-green-500' :
                         boss.difficulty === 'medium' ? 'text-yellow-500' : 'text-red-500'
                       }`}>
-                        {boss.difficulty}
+                        {difficultyLabels[boss.difficulty]}
                       </div>
                     </div>
                   </div>
@@ -308,7 +320,7 @@ const GamePlay: React.FC = () => {
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold mb-3">Choose Exercise</h3>
+            <h3 className="text-lg font-semibold mb-3">Выберите упражнение</h3>
             <div className="grid grid-cols-2 gap-3">
               {exercisesData.map((exercise) => (
                 <button
@@ -330,7 +342,7 @@ const GamePlay: React.FC = () => {
           {!hasCamera && (
             <div className="bg-yellow-600/20 border border-yellow-600 p-4 rounded-lg">
               <p className="text-yellow-200 text-sm">
-                No camera detected. You can still play using the spacebar to count reps, but progress won't be saved.
+                Камера не обнаружена. Вы можете играть, нажимая пробел для подсчёта повторов, но прогресс не будет сохранён.
               </p>
             </div>
           )}
@@ -340,7 +352,7 @@ const GamePlay: React.FC = () => {
             className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white font-bold py-4 px-6 rounded-xl text-lg transition-all duration-200 transform hover:scale-105 shadow-lg flex items-center justify-center gap-2"
           >
             <Play size={24} />
-            Start Battle
+            Начать битву
           </button>
         </div>
       )}
@@ -390,11 +402,11 @@ const GamePlay: React.FC = () => {
             <div className="grid grid-cols-3 gap-4 mb-4">
               <div className="text-center">
                 <div className="text-2xl font-bold text-blue-500">{exerciseState.reps}</div>
-                <div className="text-xs text-gray-300">Reps</div>
+                <div className="text-xs text-gray-300">Повторы</div>
               </div>
               <div className="text-center">
                 <div className="text-2xl font-bold text-green-500">{exerciseState.combo}</div>
-                <div className="text-xs text-gray-300">Combo</div>
+                <div className="text-xs text-gray-300">Комбо</div>
               </div>
               <div className="text-center">
                 <div className={`text-2xl font-bold ${
@@ -404,7 +416,7 @@ const GamePlay: React.FC = () => {
                   {exerciseState.phase === 'neutral' ? '⚪' :
                    exerciseState.phase === 'down' ? '🔴' : '🟢'}
                 </div>
-                <div className="text-xs text-gray-300 capitalize">{exerciseState.phase}</div>
+                <div className="text-xs text-gray-300 capitalize">{phaseLabels[exerciseState.phase]}</div>
               </div>
             </div>
 
@@ -423,7 +435,7 @@ const GamePlay: React.FC = () => {
               className="w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-6 rounded-lg flex items-center justify-center gap-2"
             >
               {isPlaying ? <Pause size={20} /> : <Play size={20} />}
-              {isPlaying ? 'Pause' : 'Resume'}
+              {isPlaying ? 'Пауза' : 'Продолжить'}
             </button>
           </div>
         </div>
@@ -438,10 +450,10 @@ const GamePlay: React.FC = () => {
           <h2 className={`text-3xl font-bold mb-2 ${
             gameResult === 'victory' ? 'text-green-500' : 'text-red-500'
           }`}>
-            {gameResult === 'victory' ? 'Victory!' : 'Defeat!'}
+            {gameResult === 'victory' ? 'Победа!' : 'Поражение!'}
           </h2>
           <p className="text-gray-300 mb-6">
-            You completed {exerciseState.reps} reps in {120 - timeLeft} seconds
+            Вы выполнили {exerciseState.reps} повторов за {120 - timeLeft} секунд
           </p>
 
           <div className="space-y-4">
@@ -453,13 +465,13 @@ const GamePlay: React.FC = () => {
               }}
               className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg"
             >
-              Play Again
+              Играть снова
             </button>
             <button
               onClick={() => navigate('/results')}
               className="w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-6 rounded-lg"
             >
-              View Results
+              Посмотреть результаты
             </button>
           </div>
         </div>

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Camera, Shield, Zap, Trophy, Download } from 'lucide-react';
+import { Camera, Shield, Zap, Trophy, Download, Play } from 'lucide-react';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -41,15 +41,15 @@ const Landing: React.FC = () => {
       {showInstall && (
         <div className="bg-red-600 p-3 rounded-lg mb-6 flex items-center justify-between">
           <div>
-            <p className="font-semibold">Install Fitness Boss</p>
-            <p className="text-sm opacity-90">Get the full app experience</p>
+            <p className="font-semibold">Установить Fitness Boss</p>
+            <p className="text-sm opacity-90">Получите полный опыт приложения</p>
           </div>
           <button
             onClick={handleInstallClick}
             className="bg-white text-red-600 px-4 py-2 rounded-lg font-semibold flex items-center gap-2"
           >
             <Download size={16} />
-            Install
+            Установить
           </button>
         </div>
       )}
@@ -57,10 +57,10 @@ const Landing: React.FC = () => {
       <div className="text-center mb-8">
         <div className="text-6xl mb-4">💪</div>
         <h1 className="text-4xl font-bold mb-2 bg-gradient-to-r from-red-500 to-orange-500 bg-clip-text text-transparent">
-          Fitness Boss Fight
+          Битва Фитнес Босса
         </h1>
         <p className="text-gray-300 text-lg">
-          AI-powered workout battles using your camera
+          Тренировки с ИИ через вашу камеру
         </p>
       </div>
 
@@ -68,39 +68,39 @@ const Landing: React.FC = () => {
         <div className="bg-gray-800 p-6 rounded-xl border border-gray-700">
           <div className="flex items-center gap-3 mb-3">
             <Camera className="text-red-500" size={24} />
-            <h3 className="text-xl font-semibold">How It Works</h3>
+            <h3 className="text-xl font-semibold">Как это работает</h3>
           </div>
           <ul className="space-y-2 text-gray-300">
-            <li>• Choose your boss and exercise</li>
-            <li>• Use your camera for AI pose detection</li>
-            <li>• Complete reps to damage the boss</li>
-            <li>• Win the 2-minute battle!</li>
+            <li>• Выберите босса и упражнение</li>
+            <li>• Используйте камеру для распознавания поз</li>
+            <li>• Выполняйте повторы, чтобы наносить урон боссу</li>
+            <li>• Победите в 2-минутной битве!</li>
           </ul>
         </div>
 
         <div className="bg-gray-800 p-6 rounded-xl border border-gray-700">
           <div className="flex items-center gap-3 mb-3">
             <Shield className="text-green-500" size={24} />
-            <h3 className="text-xl font-semibold">Privacy First</h3>
+            <h3 className="text-xl font-semibold">Конфиденциальность прежде всего</h3>
           </div>
           <p className="text-gray-300">
-            All processing happens locally in your browser. Your video never leaves your device.
+            Вся обработка происходит локально в вашем браузере. Видео никогда не покидает ваше устройство.
           </p>
         </div>
 
         <div className="bg-gray-800 p-6 rounded-xl border border-gray-700">
           <div className="flex items-center gap-3 mb-3">
             <Zap className="text-yellow-500" size={24} />
-            <h3 className="text-xl font-semibold">Exercises</h3>
+            <h3 className="text-xl font-semibold">Упражнения</h3>
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div className="bg-gray-700 p-3 rounded-lg text-center">
               <div className="text-2xl mb-1">🏋️</div>
-              <p className="font-semibold">Squats</p>
+              <p className="font-semibold">Приседания</p>
             </div>
             <div className="bg-gray-700 p-3 rounded-lg text-center">
               <div className="text-2xl mb-1">💪</div>
-              <p className="font-semibold">Push-ups</p>
+              <p className="font-semibold">Отжимания</p>
             </div>
           </div>
         </div>
@@ -108,19 +108,19 @@ const Landing: React.FC = () => {
         <div className="bg-gray-800 p-6 rounded-xl border border-gray-700">
           <div className="flex items-center gap-3 mb-3">
             <Trophy className="text-purple-500" size={24} />
-            <h3 className="text-xl font-semibold">Bosses</h3>
+            <h3 className="text-xl font-semibold">Боссы</h3>
           </div>
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <span>🧌 Training Goblin</span>
+              <span>🧌 Тренировочный гоблин</span>
               <span className="text-green-500">30 HP</span>
             </div>
             <div className="flex items-center justify-between">
-              <span>👹 Fitness Orc</span>
+              <span>👹 Фитнес орк</span>
               <span className="text-yellow-500">60 HP</span>
             </div>
             <div className="flex items-center justify-between">
-              <span>🐲 Gym Dragon</span>
+              <span>🐲 Дракон спортзала</span>
               <span className="text-red-500">100 HP</span>
             </div>
           </div>
@@ -132,7 +132,7 @@ const Landing: React.FC = () => {
         className="w-full bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 text-white font-bold py-4 px-6 rounded-xl text-lg transition-all duration-200 transform hover:scale-105 shadow-lg flex items-center justify-center gap-2"
       >
         <Play size={24} />
-        Start Battle
+        Начать битву
       </Link>
     </div>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,20 +13,20 @@ const Layout: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <nav className="bg-gray-800 border-b border-gray-700">
-        <div className="max-w-md mx-auto px-4">
+        <div className="max-w-md md:max-w-2xl lg:max-w-4xl mx-auto px-4">
           <div className="flex items-center justify-between h-16">
             <Link to="/" className="font-bold text-xl text-red-500">
-              💪 Fitness Boss
+              💪 Фитнес Босс
             </Link>
           </div>
         </div>
       </nav>
 
-      <main className="max-w-md mx-auto">
+      <main className="max-w-md md:max-w-2xl lg:max-w-4xl mx-auto">
         <Outlet />
       </main>
 
-      <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-md bg-gray-800 border-t border-gray-700">
+      <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-md md:max-w-2xl lg:max-w-4xl bg-gray-800 border-t border-gray-700">
         <div className="grid grid-cols-4 h-16">
           <Link
             to="/"
@@ -35,7 +35,7 @@ const Layout: React.FC = () => {
             }`}
           >
             <Home size={20} />
-            <span>Home</span>
+            <span>Главная</span>
           </Link>
           <Link
             to="/play"
@@ -44,7 +44,7 @@ const Layout: React.FC = () => {
             }`}
           >
             <Play size={20} />
-            <span>Play</span>
+            <span>Игра</span>
           </Link>
           <Link
             to="/results"
@@ -53,7 +53,7 @@ const Layout: React.FC = () => {
             }`}
           >
             <BarChart3 size={20} />
-            <span>Results</span>
+            <span>Результаты</span>
           </Link>
           <Link
             to="/profile"
@@ -62,7 +62,7 @@ const Layout: React.FC = () => {
             }`}
           >
             <User size={20} />
-            <span>Profile</span>
+            <span>Профиль</span>
           </Link>
         </div>
       </nav>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -14,7 +14,7 @@ const Profile: React.FC = () => {
   };
 
   const clearAllData = () => {
-    if (confirm('Are you sure you want to clear all data? This cannot be undone.')) {
+    if (confirm('Вы уверены, что хотите удалить все данные? Это действие нельзя отменить.')) {
       localStorage.clear();
       window.location.reload();
     }
@@ -25,42 +25,42 @@ const Profile: React.FC = () => {
         const stream = await navigator.mediaDevices.getUserMedia({ video: true });
         stream.getTracks().forEach(track => track.stop());
         updateSettings({ ...settings, cameraPermission: true });
-        alert('Camera permission granted!');
+        alert('Доступ к камере предоставлен!');
       } catch {
-        alert('Camera permission denied. Please enable camera access in your browser settings.');
+        alert('В доступе к камере отказано. Пожалуйста, включите доступ в настройках браузера.');
       }
     };
 
   return (
     <div className="p-4 pb-20">
-      <h1 className="text-2xl font-bold mb-6">Profile & Settings</h1>
+      <h1 className="text-2xl font-bold mb-6">Профиль и настройки</h1>
 
       {/* User Stats */}
       <div className="bg-gray-800 p-6 rounded-xl border border-gray-700 mb-6">
         <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
           <Settings size={24} />
-          Your Stats
+          Ваша статистика
         </h2>
         
         <div className="space-y-3">
           <div className="flex justify-between">
-            <span className="text-gray-300">Total Sessions</span>
+            <span className="text-gray-300">Всего сессий</span>
             <span className="font-semibold">{stats.totalSessions}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-300">Total Reps</span>
+            <span className="text-gray-300">Всего повторов</span>
             <span className="font-semibold">{stats.totalReps}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-300">Victories</span>
+            <span className="text-gray-300">Победы</span>
             <span className="font-semibold text-green-500">{stats.victories}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-300">Current Streak</span>
+            <span className="text-gray-300">Текущая серия</span>
             <span className="font-semibold text-orange-500">{stats.streak}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-300">Best Accuracy</span>
+            <span className="text-gray-300">Лучшая точность</span>
             <span className="font-semibold text-blue-500">{Math.round(stats.bestAccuracy)}%</span>
           </div>
         </div>
@@ -68,14 +68,14 @@ const Profile: React.FC = () => {
 
       {/* Settings */}
       <div className="bg-gray-800 p-6 rounded-xl border border-gray-700 mb-6">
-        <h2 className="text-xl font-semibold mb-4">Settings</h2>
+        <h2 className="text-xl font-semibold mb-4">Настройки</h2>
         
         <div className="space-y-4">
           {/* Sound Toggle */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               {settings.soundEnabled ? <Volume2 size={20} /> : <VolumeX size={20} />}
-              <span>Sound Effects</span>
+              <span>Звуковые эффекты</span>
             </div>
             <button
               onClick={() => updateSettings({ ...settings, soundEnabled: !settings.soundEnabled })}
@@ -95,7 +95,7 @@ const Profile: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Smartphone size={20} />
-              <span>Vibration</span>
+              <span>Вибрация</span>
             </div>
             <button
               onClick={() => updateSettings({ ...settings, vibrationEnabled: !settings.vibrationEnabled })}
@@ -115,16 +115,16 @@ const Profile: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Camera size={20} />
-              <span>Camera Access</span>
+              <span>Доступ к камере</span>
             </div>
             {settings.cameraPermission ? (
-              <span className="text-green-500 text-sm">✓ Granted</span>
+              <span className="text-green-500 text-sm">✓ Разрешено</span>
             ) : (
               <button
                 onClick={requestCameraPermission}
                 className="bg-red-600 hover:bg-red-700 px-4 py-2 rounded-lg text-sm"
               >
-                Grant Access
+                Разрешить
               </button>
             )}
           </div>
@@ -133,28 +133,28 @@ const Profile: React.FC = () => {
 
       {/* Privacy Info */}
       <div className="bg-gray-800 p-6 rounded-xl border border-gray-700 mb-6">
-        <h2 className="text-xl font-semibold mb-4">Privacy & Data</h2>
+        <h2 className="text-xl font-semibold mb-4">Конфиденциальность и данные</h2>
         <div className="space-y-3 text-sm text-gray-300">
-          <p>✅ All video processing happens locally on your device</p>
-          <p>✅ No video data is ever sent to servers</p>
-          <p>✅ Only session statistics are stored locally</p>
-          <p>✅ No personal data is collected or shared</p>
-          <p>✅ Works completely offline after initial load</p>
+          <p>✅ Вся обработка видео происходит локально на вашем устройстве</p>
+          <p>✅ Видео не отправляется на серверы</p>
+          <p>✅ Локально сохраняется только статистика</p>
+          <p>✅ Персональные данные не собираются и не передаются</p>
+          <p>✅ Работает полностью офлайн после начальной загрузки</p>
         </div>
       </div>
 
       {/* Data Management */}
       <div className="bg-gray-800 p-6 rounded-xl border border-gray-700">
-        <h2 className="text-xl font-semibold mb-4 text-red-400">Data Management</h2>
+        <h2 className="text-xl font-semibold mb-4 text-red-400">Управление данными</h2>
         <p className="text-gray-300 text-sm mb-4">
-          This will permanently delete all your session data, statistics, and settings.
+          Это навсегда удалит все ваши данные, статистику и настройки.
         </p>
         <button
           onClick={clearAllData}
           className="bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-6 rounded-lg flex items-center gap-2 transition-colors"
         >
           <Trash2 size={20} />
-          Clear All Data
+          Очистить все данные
         </button>
       </div>
     </div>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -5,6 +5,12 @@ import type { GameSession } from '../types';
 import bossesData from '../data/bosses.json';
 import exercisesData from '../data/exercises.json';
 
+const difficultyLabels: Record<string, string> = {
+  easy: 'легкий',
+  medium: 'средний',
+  hard: 'сложный'
+};
+
 const Results: React.FC = () => {
   const storageManager = new StorageManager();
   const sessions = storageManager.getSessions();
@@ -17,60 +23,60 @@ const Results: React.FC = () => {
 
   return (
     <div className="p-4 pb-20">
-      <h1 className="text-2xl font-bold mb-6">Battle Results</h1>
+      <h1 className="text-2xl font-bold mb-6">Результаты битв</h1>
 
       {/* Stats Overview */}
       <div className="grid grid-cols-2 gap-4 mb-6">
         <div className="bg-gray-800 p-4 rounded-xl border border-gray-700">
           <div className="flex items-center gap-2 mb-2">
             <Trophy className="text-yellow-500" size={20} />
-            <span className="text-sm text-gray-300">Victories</span>
+            <span className="text-sm text-gray-300">Победы</span>
           </div>
           <div className="text-2xl font-bold">{stats.victories}</div>
           <div className="text-xs text-gray-400">
-            {stats.totalSessions > 0 ? Math.round((stats.victories / stats.totalSessions) * 100) : 0}% win rate
+            {stats.totalSessions > 0 ? Math.round((stats.victories / stats.totalSessions) * 100) : 0}% процент побед
           </div>
         </div>
 
         <div className="bg-gray-800 p-4 rounded-xl border border-gray-700">
           <div className="flex items-center gap-2 mb-2">
             <Zap className="text-orange-500" size={20} />
-            <span className="text-sm text-gray-300">Current Streak</span>
+            <span className="text-sm text-gray-300">Текущая серия</span>
           </div>
           <div className="text-2xl font-bold">{stats.streak}</div>
-          <div className="text-xs text-gray-400">battles</div>
+          <div className="text-xs text-gray-400">битв</div>
         </div>
 
         <div className="bg-gray-800 p-4 rounded-xl border border-gray-700">
           <div className="flex items-center gap-2 mb-2">
             <Target className="text-blue-500" size={20} />
-            <span className="text-sm text-gray-300">Total Reps</span>
+            <span className="text-sm text-gray-300">Всего повторов</span>
           </div>
           <div className="text-2xl font-bold">{stats.totalReps}</div>
           <div className="text-xs text-gray-400">
-            {stats.totalSessions > 0 ? Math.round(stats.totalReps / stats.totalSessions) : 0} avg per session
+            {stats.totalSessions > 0 ? Math.round(stats.totalReps / stats.totalSessions) : 0} в среднем за сессию
           </div>
         </div>
 
         <div className="bg-gray-800 p-4 rounded-xl border border-gray-700">
           <div className="flex items-center gap-2 mb-2">
             <Clock className="text-green-500" size={20} />
-            <span className="text-sm text-gray-300">Best Accuracy</span>
+            <span className="text-sm text-gray-300">Лучшая точность</span>
           </div>
           <div className="text-2xl font-bold">{Math.round(stats.bestAccuracy)}%</div>
-          <div className="text-xs text-gray-400">peak performance</div>
+          <div className="text-xs text-gray-400">пиковая форма</div>
         </div>
       </div>
 
       {/* Recent Sessions */}
       <div className="mb-6">
-        <h2 className="text-xl font-semibold mb-4">Recent Battles</h2>
+        <h2 className="text-xl font-semibold mb-4">Недавние битвы</h2>
         
         {recentSessions.length === 0 ? (
           <div className="bg-gray-800 p-6 rounded-xl border border-gray-700 text-center">
             <div className="text-4xl mb-3">⚔️</div>
-            <p className="text-gray-300">No battles yet!</p>
-            <p className="text-sm text-gray-400 mt-1">Start your first battle to see results here</p>
+            <p className="text-gray-300">Пока нет битв!</p>
+            <p className="text-sm text-gray-400 mt-1">Начните первую битву, чтобы увидеть результаты здесь</p>
           </div>
         ) : (
           <div className="space-y-3">
@@ -89,9 +95,9 @@ const Results: React.FC = () => {
                     <div className="flex items-center gap-2">
                       <span className="text-2xl">{boss?.avatar || '❓'}</span>
                       <div>
-                        <div className="font-semibold text-sm">{boss?.name || 'Unknown Boss'}</div>
+                        <div className="font-semibold text-sm">{boss?.name || 'Неизвестный босс'}</div>
                         <div className="text-xs text-gray-400">
-                          {exercise?.name || 'Unknown Exercise'}
+                          {exercise?.name || 'Неизвестное упражнение'}
                         </div>
                       </div>
                     </div>
@@ -103,20 +109,20 @@ const Results: React.FC = () => {
                   <div className="grid grid-cols-3 gap-4 text-center">
                     <div>
                       <div className="text-lg font-bold text-blue-500">{session.reps}</div>
-                      <div className="text-xs text-gray-400">Reps</div>
+                      <div className="text-xs text-gray-400">Повторы</div>
                     </div>
                     <div>
                       <div className="text-lg font-bold text-purple-500">{Math.round(session.accuracy)}%</div>
-                      <div className="text-xs text-gray-400">Accuracy</div>
+                      <div className="text-xs text-gray-400">Точность</div>
                     </div>
                     <div>
                       <div className="text-lg font-bold text-orange-500">{session.duration}s</div>
-                      <div className="text-xs text-gray-400">Duration</div>
+                      <div className="text-xs text-gray-400">Длительность</div>
                     </div>
                   </div>
                   
                   <div className="text-xs text-gray-500 mt-2">
-                    {new Date(session.timestamp).toLocaleDateString()} at {new Date(session.timestamp).toLocaleTimeString()}
+                    {new Date(session.timestamp).toLocaleDateString()} в {new Date(session.timestamp).toLocaleTimeString()}
                   </div>
                 </div>
               );
@@ -127,7 +133,7 @@ const Results: React.FC = () => {
 
       {/* Boss Progress */}
       <div className="mb-6">
-        <h2 className="text-xl font-semibold mb-4">Boss Progress</h2>
+        <h2 className="text-xl font-semibold mb-4">Прогресс боссов</h2>
         <div className="space-y-3">
           {bossesData.map((boss) => {
             const bossVictories = sessions.filter(s => s.bossId === boss.id && s.victory).length;
@@ -145,13 +151,13 @@ const Results: React.FC = () => {
                         boss.difficulty === 'easy' ? 'text-green-500' :
                         boss.difficulty === 'medium' ? 'text-yellow-500' : 'text-red-500'
                       }`}>
-                        {boss.difficulty} - {boss.maxHP} HP
+                        {difficultyLabels[boss.difficulty]} - {boss.maxHP} HP
                       </div>
                     </div>
                   </div>
                   <div className="text-right">
                     <div className="text-lg font-bold">{bossVictories}/{bossAttempts}</div>
-                    <div className="text-xs text-gray-400">{winRate}% win rate</div>
+                    <div className="text-xs text-gray-400">{winRate}% процент побед</div>
                   </div>
                 </div>
                 

--- a/src/data/bosses.json
+++ b/src/data/bosses.json
@@ -1,26 +1,26 @@
 [
   {
     "id": "goblin",
-    "name": "Training Goblin",
+    "name": "Тренировочный гоблин",
     "difficulty": "easy",
     "maxHP": 30,
     "avatar": "🧌",
-    "description": "A weak opponent perfect for beginners"
+    "description": "Слабый противник, идеально подходящий для новичков"
   },
   {
     "id": "orc",
-    "name": "Fitness Orc",
-    "difficulty": "medium", 
+    "name": "Фитнес орк",
+    "difficulty": "medium",
     "maxHP": 60,
     "avatar": "👹",
-    "description": "A challenging mid-level boss"
+    "description": "Сложный босс среднего уровня"
   },
   {
     "id": "dragon",
-    "name": "Gym Dragon",
+    "name": "Дракон спортзала",
     "difficulty": "hard",
     "maxHP": 100,
     "avatar": "🐲",
-    "description": "The ultimate fitness challenge"
+    "description": "Высшее фитнес-испытание"
   }
 ]

--- a/src/data/exercises.json
+++ b/src/data/exercises.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "squat",
-    "name": "Squats",
+    "name": "Приседания",
     "icon": "🏋️",
-    "description": "Bend your knees until thigh is parallel to ground",
+    "description": "Сгибайте колени, пока бедро не станет параллельно полу",
     "detection": {
       "downAngle": 85,
       "upAngle": 165,
@@ -13,9 +13,9 @@
   },
   {
     "id": "pushup",
-    "name": "Push-ups", 
+    "name": "Отжимания",
     "icon": "💪",
-    "description": "Lower your body until chest nearly touches ground",
+    "description": "Опускайте тело, пока грудь почти не касается земли",
     "detection": {
       "downAngle": 70,
       "upAngle": 160,


### PR DESCRIPTION
## Summary
- translate interface text to Russian and add Russian navigation labels
- expand layout widths for better responsiveness and expose a dedicated Play tab
- define game-ending logic before start/pause callbacks to prevent runtime errors
- remove placeholder PWA icons and related manifest entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7899a853c832391a15577fe9f2dd2